### PR TITLE
Fix ElectroDB ignoreOwnership for backward compatibility with existin…

### DIFF
--- a/src/repository/album-art.repository.ts
+++ b/src/repository/album-art.repository.ts
@@ -3,11 +3,11 @@ import { AlbumArtEntity } from './entities/album-art.entity';
 
 export class AlbumArtRepository {
   public async getAlbumArt(trackId: string): Promise<AlbumArtDto | undefined> {
-    const result = await AlbumArtEntity.get({ id: trackId }).go();
+    const result = await AlbumArtEntity.get({ id: trackId }).go({ ignoreOwnership: true });
     return (result.data as AlbumArtDto) ?? undefined;
   }
 
   public async addAlbumArt(albumArt: AlbumArtDto) {
-    await AlbumArtEntity.put(albumArt).go();
+    await AlbumArtEntity.put(albumArt).go({ ignoreOwnership: true });
   }
 }

--- a/src/repository/device.repository.ts
+++ b/src/repository/device.repository.ts
@@ -3,18 +3,18 @@ import { DeviceEntity } from './entities/device.entity';
 
 export class DeviceRepository {
   public async getDevice(token: string): Promise<DeviceDto | undefined> {
-    const result = await DeviceEntity.get({ token }).go();
+    const result = await DeviceEntity.get({ token }).go({ ignoreOwnership: true });
     return (result.data as DeviceDto) ?? undefined;
   }
 
   public async putDevice(device: DeviceDto) {
-    await DeviceEntity.put(device).go();
+    await DeviceEntity.put(device).go({ ignoreOwnership: true });
   }
 
   public async getDevicesByStatus(status: number, limit?: number): Promise<DeviceDto[]> {
     const result = await DeviceEntity.query
       .byStatusSubscribedAt({ status })
-      .go({ order: 'asc', limit });
+      .go({ order: 'asc', limit, ignoreOwnership: true });
 
     return result.data as DeviceDto[];
   }
@@ -23,16 +23,16 @@ export class DeviceRepository {
     const result = await DeviceEntity.query
       .byStatusSubscribedAt({ status })
       .lte({ subscribedAt: ts })
-      .go();
+      .go({ ignoreOwnership: true });
 
     return result.data as DeviceDto[];
   }
 
   public async deleteDevices(tokens: string[]) {
-    await DeviceEntity.delete(tokens.map((token) => ({ token }))).go();
+    await DeviceEntity.delete(tokens.map((token) => ({ token }))).go({ ignoreOwnership: true });
   }
 
   public async createDevices(devices: DeviceDto[]) {
-    await DeviceEntity.put(devices).go();
+    await DeviceEntity.put(devices).go({ ignoreOwnership: true });
   }
 }

--- a/src/repository/schedule.repository.ts
+++ b/src/repository/schedule.repository.ts
@@ -5,7 +5,7 @@ import { ScheduleEntity } from './entities/schedule.entity';
 export class ScheduleRepository {
   public async getFullSchedule(): Promise<ShowDto[]> {
     try {
-      const result = await ScheduleEntity.scan.go({ pages: 'all' });
+      const result = await ScheduleEntity.scan.go({ pages: 'all', ignoreOwnership: true });
       return result.data as ShowDto[];
     } catch (err) {
       log.error(`Error getting schedule from db ${err}`);

--- a/src/repository/track-list.repository.ts
+++ b/src/repository/track-list.repository.ts
@@ -3,7 +3,7 @@ import { TrackEntity } from './entities/track.entity';
 
 export class TrackListRepository {
   public async putTrack(track: TrackDto) {
-    await TrackEntity.put(track).go();
+    await TrackEntity.put(track).go({ ignoreOwnership: true });
   }
 
   public async getLastTracks(
@@ -19,6 +19,7 @@ export class TrackListRepository {
     const results = await TrackEntity.query.byRadio({ radio }).go({
       order: 'desc',
       limit,
+      ignoreOwnership: true,
       cursor:
         lastSongKey != null
           ? JSON.stringify({


### PR DESCRIPTION
…g data

Existing DynamoDB items lack ElectroDB metadata fields (__edb_e__, __edb_v__), causing queries/scans to return empty results. Adding ignoreOwnership: true to all .go() calls ensures existing data is readable.

https://claude.ai/code/session_016StXHFh45dtHdRoZpw3oMC